### PR TITLE
Make it work with Meteor 1.2

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   "summary": "Server Side Rendering for Meteor with Blaze",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "git": "https://github.com/meteorhacks/meteor-ssr",
   "name": "meteorhacks:ssr"
 });
@@ -14,7 +14,7 @@ Package.onTest(function(api) {
   configurePackage(api);
   api.use([
     'tinytest',
-    'mquandalle:jade-compiler@0.4.0_3'
+    'mquandalle:jade-compiler@0.4.4'
   ], 'server');
 
   api.addFiles([
@@ -24,9 +24,9 @@ Package.onTest(function(api) {
 });
 
 function configurePackage(api) {
-  api.versionsFrom('METEOR@0.9.2');
-  api.use(['blaze', 'spacebars', 'spacebars-compiler'], 'server');
-  api.use('jade-compiler@0.4.0_3', { weak: true });
+  api.versionsFrom('METEOR@1.2.0.1');
+  api.use('mquandalle:jade-compiler@0.4.4', { weak: true });
+  api.use(['blaze', 'spacebars', 'spacebars-compiler', 'mongo', 'random'], 'server');
   api.addFiles([
     'lib/overrides.js',
     'lib/template.js',


### PR DESCRIPTION
Updated package to work with Meteor 1.2
- Package for Jade updated to `0.4.4`, which is the Meteor 1.2 compatible package.
- Added explicit deps that are no longer globally included (`random` and `mongo`)
- Tests are passing
