### PR TITLE
mquandalle:jade-compiler added in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ If not provided this default to `html` which is handled by the spacebars compile
 You can also use `jade` as another option — and in this case you need to add following package:
 ~~~
 meteor add mquandalle:jade
+meteor add mquandalle:jade-compiler
 ~~~
 
 Note: the order in which you add jade and SSR matters! First add jade as a dependency and then SSR, otherwise the jade-compiler can not be located by Meteor.


### PR DESCRIPTION
Adding just mquandalle:jade wasn't enough, however, based on source code it's become clear that mquandalle:jade-compiler required, thus adding this package implicit it make things work